### PR TITLE
Fix code scanning alert no. 56: Jinja2 templating with autoescape=False

### DIFF
--- a/pr_insight/tools/pr_code_suggestions.py
+++ b/pr_insight/tools/pr_code_suggestions.py
@@ -601,7 +601,7 @@ class PRCodeSuggestions:
 
             variables = {'suggestion_list': suggestion_list, 'suggestion_str': suggestion_str}
             model = get_settings().config.model
-            environment = Environment(undefined=StrictUndefined)
+            environment = Environment(undefined=StrictUndefined, autoescape=select_autoescape(['html', 'xml']))
             system_prompt = environment.from_string(get_settings().pr_sort_code_suggestions_prompt.system).render(
                 variables)
             user_prompt = environment.from_string(get_settings().pr_sort_code_suggestions_prompt.user).render(variables)


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/pr-insight/security/code-scanning/56](https://github.com/khulnasoft/pr-insight/security/code-scanning/56)

To fix the problem, we need to ensure that the Jinja2 `Environment` is created with `autoescape` enabled. This can be done by using the `select_autoescape` function, which will automatically enable escaping for HTML and XML files. This change will prevent XSS vulnerabilities by ensuring that any untrusted input is properly escaped.

- Modify the creation of the `Environment` object to include `autoescape=select_autoescape(['html', 'xml'])`.
- This change should be made in the `rank_suggestions` method where the `Environment` object is instantiated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Enable autoescaping in Jinja2 Environment to prevent XSS vulnerabilities by using select_autoescape for HTML and XML files.