### PR TITLE
Add support for processing diffs without line numbers

### DIFF
--- a/docs/docs/core-abilities/self_reflection.md
+++ b/docs/docs/core-abilities/self_reflection.md
@@ -46,6 +46,5 @@ This results in a more refined and valuable set of suggestions for the user, sav
 ## Appendix - Relevant Configuration Options
 ```
 [pr_code_suggestions]
-self_reflect_on_suggestions	= true # Enable self-reflection on code suggestions
 suggestions_score_threshold	= 0 # Filter out suggestions with a score below this threshold (0-10)
 ```

--- a/docs/docs/tools/improve.md
+++ b/docs/docs/tools/improve.md
@@ -280,10 +280,6 @@ Using a combination of both can help the AI model to provide relevant and tailor
         <td>If set to true, the improve comment will be persistent, meaning that every new improve request will edit the previous one. Default is false.</td>
       </tr>
       <tr>
-        <td><b>self_reflect_on_suggestions</b></td>
-        <td>If set to true, the improve tool will calculate an importance score for each suggestion [1-10], and sort the suggestion labels group based on this score. Default is true.</td>
-      </tr>
-      <tr>
         <td><b>suggestions_score_threshold</b></td>
         <td> Any suggestion with importance score less than this threshold will be removed. Default is 0. Highly recommend not to set this value above 7-8, since above it may clip relevant suggestions that can be useful. </td>
       </tr>

--- a/pr_insight/settings/configuration.toml
+++ b/pr_insight/settings/configuration.toml
@@ -122,7 +122,6 @@ max_history_len=4
 # enable to apply suggestion 💎
 apply_suggestions_checkbox=true
 # suggestions scoring
-self_reflect_on_suggestions=true
 suggestions_score_threshold=0 # [0-10]| recommend not to set this value above 8, since above it may clip highly relevant suggestions
 # params for '/improve --extended' mode
 auto_extended_mode=true

--- a/pr_insight/settings/pr_code_suggestions_prompts.toml
+++ b/pr_insight/settings/pr_code_suggestions_prompts.toml
@@ -14,10 +14,10 @@ The PR code diff will be in the following structured format:
 
 @@ ... @@ def func1():
 __new hunk__
-11  unchanged code line0 in the PR
-12  unchanged code line1 in the PR
-13 +new code line2 added in the PR
-14  unchanged code line3 in the PR
+ unchanged code line0 in the PR
+ unchanged code line1 in the PR
++new code line2 added in the PR
+ unchanged code line3 in the PR
 __old hunk__
  unchanged code line0
  unchanged code line1
@@ -35,7 +35,6 @@ __new hunk__
 ======
 
 - In the format above, the diff is organized into separate '__new hunk__' and '__old hunk__' sections for each code chunk. '__new hunk__' contains the updated code, while '__old hunk__' shows the removed code. If no code was removed in a specific chunk, the __old hunk__ section will be omitted.
-- Line numbers were added for the '__new hunk__' sections to help referencing specific lines in the code suggestions. These numbers are for reference only and are not part of the actual code.
 - Code lines are prefixed with symbols: '+' for new code added in the PR, '-' for code removed, and ' ' for unchanged code.
 {%- if is_ai_metadata %}
 - When available, an AI-generated summary will precede each file's diff, with a high-level overview of the changes. Note that this summary may not be fully accurate or complete.
@@ -44,7 +43,7 @@ __new hunk__
 
 Specific guidelines for generating code suggestions:
 - Provide up to {{ num_code_suggestions }} distinct and insightful code suggestions.
-- Focus solely on enhancing new code introduced in the PR, identified by '+' prefixes in '__new hunk__' sections (after the line numbers).
+- Focus solely on enhancing new code introduced in the PR, identified by '+' prefixes in '__new hunk__' sections.
 - Prioritize suggestions that address potential issues, critical problems, and bugs in the PR code. Avoid repeating changes already implemented in the PR. If no pertinent suggestions are applicable, return an empty list.
 - Don't suggest to add docstring, type hints, or comments, to remove unused imports, or to use more specific exception types.
 - When referencing variables or names from the code, enclose them in backticks (`). Example: "ensure that `variable_name` is..."
@@ -67,12 +66,10 @@ class CodeSuggestion(BaseModel):
     relevant_file: str = Field(description="Full path of the relevant file")
     language: str = Field(description="Programming language used by the relevant file")
     suggestion_content: str = Field(description="An actionable suggestion to enhance, improve or fix the new code introduced in the PR. Don't present here actual code snippets, just the suggestion. Be short and concise")
-    existing_code: str = Field(description="A short code snippet from a '__new hunk__' section that the suggestion aims to enhance or fix. Include only complete code lines, without line numbers. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
+    existing_code: str = Field(description="A short code snippet from a '__new hunk__' section that the suggestion aims to enhance or fix. Include only complete code lines. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
     improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion.")
     one_sentence_summary: str = Field(description="A concise, single-sentence overview of the suggested improvement. Focus on the 'what'. Be general, and avoid method or variable names.")
-    relevant_lines_start: int = Field(description="The relevant line number, from a '__new hunk__' section, where the suggestion starts (inclusive). Should be derived from the hunk line numbers, and correspond to the beginning of the 'existing code' snippet above")
-    relevant_lines_end: int = Field(description="The relevant line number, from a '__new hunk__' section, where the suggestion ends (inclusive). Should be derived from the hunk line numbers, and correspond to the end of the 'existing code' snippet above")
-    label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability'. Other relevant labels are also acceptable.")
+    label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability', 'typo'. Other relevant labels are also acceptable.")
 
 
 class PRCodeSuggestions(BaseModel):
@@ -95,8 +92,6 @@ code_suggestions:
     ...
   one_sentence_summary: |
     ...
-  relevant_lines_start: 12
-  relevant_lines_end: 13
   label: |
     ...
 ```
@@ -112,7 +107,7 @@ Title: '{{title}}'
 
 The PR Diff:
 ======
-{{ diff|trim }}
+{{ diff_no_line_numbers|trim }}
 ======
 
 

--- a/pr_insight/settings/pr_code_suggestions_reflect_prompts.toml
+++ b/pr_insight/settings/pr_code_suggestions_reflect_prompts.toml
@@ -15,7 +15,8 @@ Be particularly vigilant for suggestions that:
     - Contradict or ignore parts of the PR's modifications
 In such cases, assign the suggestion a score of 0.
 
-For valid suggestions, your role is to provide an impartial and precise score assessment that accurately reflects each suggestion's potential impact on the PR's correctness, quality and functionality.
+valuate each valid suggestion by scoring its potential impact on the PR's correctness, quality and functionality.
+In addition, you should also detect the line numbers in the '__new hunk__' section that correspond to the 'existing_code' snippet.
 
 
 Key guidelines for evaluation:
@@ -82,6 +83,8 @@ The output must be a YAML object equivalent to type $PRCodeSuggestionsFeedback, 
 class CodeSuggestionFeedback(BaseModel):
     suggestion_summary: str = Field(description="Repeated from the input")
     relevant_file: str = Field(description="Repeated from the input")
+    relevant_lines_start: int = Field(description="The relevant line number, from a '__new hunk__' section, where the suggestion starts (inclusive). Should be derived from the hunk line numbers, and correspond to the beginning of the relevant 'existing code' snippet")
+    relevant_lines_end: int = Field(description="The relevant line number, from a '__new hunk__' section, where the suggestion ends (inclusive). Should be derived from the hunk line numbers, and correspond to the end of the relevant 'existing code' snippet")
     suggestion_score: int = Field(description="Evaluate the suggestion and assign a score from 0 to 10. Give 0 if the suggestion is wrong. For valid suggestions, score from 1 (lowest impact/importance) to 10 (highest impact/importance).")
     why: str = Field(description="Briefly explain the score given in 1-2 sentences, focusing on the suggestion's impact, relevance, and accuracy.")
 
@@ -96,6 +99,8 @@ code_suggestions:
 - suggestion_summary: |
     Use a more descriptive variable name here
   relevant_file: "src/file1.py"
+  relevant_lines_start: 13
+  relevant_lines_end: 14
   suggestion_score: 6
   why: |
     The variable name 't' is not descriptive enough

--- a/pr_insight/tools/pr_code_suggestions.py
+++ b/pr_insight/tools/pr_code_suggestions.py
@@ -114,8 +114,8 @@ class PRCodeSuggestions:
 
             if (data is None or 'code_suggestions' not in data or not data['code_suggestions']):
                 pr_body = "## PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
-                get_logger().warning('No code suggestions found for the PR.')
-                if get_settings().config.publish_output and get_settings().config.publish_output_no_suggestions:
+                if get_settings().config.publish_output:
+                    get_logger().warning('No code suggestions found for the PR.')
                     get_logger().debug(f"PR output", artifact=pr_body)
                     if self.progress_response:
                         self.git_provider.edit_comment(self.progress_response, body=pr_body)


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Summary by Sourcery

Documentation:
- Remove the 'self_reflect_on_suggestions' configuration option from the self_reflection documentation.