### PR TITLE
fix: add fallback for parsing AI responses with leading '+' symbols

### DIFF
--- a/pr_insight/algo/utils.py
+++ b/pr_insight/algo/utils.py
@@ -735,7 +735,7 @@ def try_fix_yaml(response_text: str,
         get_logger().info(f"Successfully parsed AI prediction after adding |-\n")
         return data
     except:
-        get_logger().info(f"Failed to parse AI prediction after adding |-\n")
+        pass
 
     # second fallback - try to extract only range from first ```yaml to ````
     snippet_pattern = r'```(yaml)?[\s\S]*?```'
@@ -779,8 +779,18 @@ def try_fix_yaml(response_text: str,
         except:
             pass
 
+    # fifth fallback - try to remove leading '+' (sometimes added by AI for 'existing code' and 'improved code')
+    response_text_lines_copy = response_text_lines.copy()
+    for i in range(0, len(response_text_lines_copy)):
+        response_text_lines_copy[i] = ' ' + response_text_lines_copy[i][1:]
+    try:
+        data = yaml.safe_load('\n'.join(response_text_lines_copy))
+        get_logger().info(f"Successfully parsed AI prediction after removing leading '+'")
+        return data
+    except:
+        pass
 
-    # fifth fallback - try to remove last lines
+    # sixth fallback - try to remove last lines
     data = {}
     for i in range(1, len(response_text_lines)):
         response_text_lines_tmp = '\n'.join(response_text_lines[:-i])


### PR DESCRIPTION
### **User description**
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
Bug fix


___

### **Description**
- Added a fallback to handle AI responses with leading '+' symbols.

- Improved robustness of YAML parsing in `try_fix_yaml`.

- Adjusted fallback sequence for better error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Added fallback for leading '+' in AI responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_insight/algo/utils.py

<li>Added a new fallback to handle AI responses with leading '+' symbols.<br> <li> Adjusted fallback numbering and sequence for clarity.<br> <li> Improved logging for successful parsing attempts.


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/pr-insight/pull/104/files#diff-adf5db62f6246913aaeaef4d88db882faa62e7da08990e40be795f1cd598536b">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>